### PR TITLE
Adds a method to cleanup nock

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,10 @@ const lastCall = queryMock.getCalls().pop();
 expect(lastCall.headers['Authorization']).toBe('Bearer mock-token');
 ```
 
+#### `queryMock.cleanup()`
+
+Runs a cleanup on nock to re-enable real network requests on the mocked endpoint.
+
 ## FAQ
 
 ##### Why use `nock`, why not just mock `fetch`?

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -67,5 +67,6 @@ declare module 'graphql-query-test-mock' {
     mockQueryWithControlledResolution(config: MockGraphQLConfig): () => void;
     getQueryMock(name: string): MockGraphQLRecord | undefined;
     setup(graphQLURL: string): void;
+    cleanup(): void;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -285,4 +285,9 @@ export class QueryMock {
       .post(theUrl.path || '/')
       .reply(getNockRequestHandlerFn(this));
   }
+
+  cleanup() {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  }
 }


### PR DESCRIPTION
This adds a method to clean `nock` and disable it from mocking the network layer.

This is useful when in the same test file you start another scenario that creates mocks for the same endpoint that `nock` is already taking care.