### PR TITLE
Ignore the order of the properties when matching on the variables object

### DIFF
--- a/__tests__/queryMock-tests.js
+++ b/__tests__/queryMock-tests.js
@@ -206,25 +206,47 @@ describe('queryMock', () => {
     beforeEach(() => {
       mockData = { some: 'data' };
       mockVariables = {
-        firstParam: [
-          {
-            firstNestedParam: 'firstNestedParam 1',
-            secondNestedParam: 'secondNestedParam 1'
-          },
-          {
-            firstNestedParam: 'firstNestedParam 2',
-            secondNestedParam: 'secondNestedParam 2'
-          }
-        ],
-        secondParam: 'secondParam'
+        includeStuff: true,
+        withStuff: true,
+        filterOn: [123, 345],
+        after: 'cursor'
       };
     });
 
     describe('By object', () => {
-      it('should match on the variables object no matter the order of the object properties', async () => {
+      it('should make sure variables match provided variables object if provided', async () => {
         queryMock.mockQuery({
           name: 'TestQuery',
           variables: mockVariables,
+          data: mockData
+        });
+
+        const res = await fetchQuery(
+          {
+            text: 'query TestQuery { id }'
+          },
+          mockVariables
+        );
+
+        expect(res.data).toEqual(mockData);
+      });
+
+      it('should match on the variables object no matter the order of the object properties', async () => {
+        queryMock.mockQuery({
+          name: 'TestQuery',
+          variables: {
+            firstParam: [
+              {
+                firstNestedParam: 'firstNestedParam 1',
+                secondNestedParam: 'secondNestedParam 1'
+              },
+              {
+                firstNestedParam: 'firstNestedParam 2',
+                secondNestedParam: 'secondNestedParam 2'
+              }
+            ],
+            secondParam: 'secondParam'
+          },
           data: mockData
         });
 
@@ -253,7 +275,9 @@ describe('queryMock', () => {
       it('should not match on the provided variables object if arrays are not ordered the same way', async () => {
         queryMock.mockQuery({
           name: 'TestQuery',
-          variables: mockVariables,
+          variables: {
+            param: [{ id: 1 }, { id: 2 }]
+          },
           data: mockData
         });
 
@@ -265,17 +289,7 @@ describe('queryMock', () => {
               text: 'query TestQuery { id }'
             },
             {
-              firstParam: [
-                {
-                  firstNestedParam: 'firstNestedParam 2',
-                  secondNestedParam: 'secondNestedParam 2'
-                },
-                {
-                  firstNestedParam: 'firstNestedParam 1',
-                  secondNestedParam: 'secondNestedParam 1'
-                }
-              ],
-              secondParam: 'secondParam'
+              param: [{ id: 2 }, { id: 1 }]
             }
           );
         } catch (e) {
@@ -368,7 +382,7 @@ describe('queryMock', () => {
       it('should allow matching variables with custom function', async () => {
         queryMock.mockQuery({
           name: 'TestQuery',
-          matchVariables: variables => variables.secondParam === 'secondParam',
+          matchVariables: variables => variables.includeStuff === true,
           data: mockData
         });
 

--- a/flow-typed/npm/object-hash_v1.x.x.js
+++ b/flow-typed/npm/object-hash_v1.x.x.js
@@ -1,0 +1,26 @@
+// flow-typed signature: c4660288ee9448120f76989773c472fc
+// flow-typed version: 7116c6f404/object-hash_v1.x.x/flow_>=v0.25.x
+
+/**
+ * Flow libdef for 'object-hash'
+ * See https://www.npmjs.com/package/object-hash
+ * by Vincent Driessen, 2018-12-21
+ */
+
+declare module 'object-hash' {
+  declare type Options = {|
+    algorithm?: 'sha1' | 'sha256' | 'md5',
+    excludeValues?: boolean,
+    encoding?: 'buffer' | 'hex' | 'binary' | 'base64',
+    ignoreUnknown?: boolean,
+    unorderedArrays?: boolean,
+    unorderedSets?: boolean,
+    unorderedObjects?: boolean,
+    excludeKeys?: string => boolean
+  |};
+
+  declare export default (
+    value: { +[string]: mixed } | Array<mixed>,
+    options?: Options
+  ) => string;
+}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
   "dependencies": {
     "deep-equal": "^1.0.1",
     "graphql": "^14.0.2",
-    "jest-diff": "^23.6.0"
+    "jest-diff": "^23.6.0",
+    "object-hash": "^1.3.1"
   },
   "peerDependencies": {
     "nock": "^9.6.1"

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 // @flow strict
+import hash from 'object-hash';
 import { DEFAULT_CONFIG } from './defaults';
 import type { MockGraphQLConfig, MockGraphQLRecord } from './index';
 import type { Variables } from './types';
@@ -13,7 +14,7 @@ export function getQueryMockID(
     ignoreThesePropertiesInVariables
   );
 
-  return `${queryName}__${JSON.stringify(processedVariables)}`;
+  return `${queryName}__${hash.sha1(processedVariables)}`;
 }
 
 export function getVariables(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4161,6 +4161,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
+  integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
+
 object-keys@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"


### PR DESCRIPTION
Hello @zth,

Currently we won't get a match if the order of the properties of the `variables` object are not identical. That means:

`{param1:  '1', param2: '2'}` will not match  `{param2:  '2', param1: '1'}`

This PR fixes that by using `object-hash` to get a fingerprint of the `variables` object.

Cheers,
J 