### PR TITLE
Drop supports for Node <8

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,11 @@
 {
-  "presets": ["@babel/flow", "@babel/env"],
+  "presets": [
+    "@babel/flow",
+    ["@babel/env", {
+      "targets": {
+        "node": "8"
+      }
+    }]
+  ],
   "plugins": ["@babel/plugin-proposal-class-properties", "@babel/plugin-proposal-object-rest-spread"]
 }


### PR DESCRIPTION
This removes the dependency on "babel-polyfill" that was introduced by commit https://github.com/zth/graphql-query-test-mock/commit/99cf4837247ffa529747154f501c62b58878d1c4 because it uses async / await. 

