### PR TITLE
Call nock.restore() in cleanup method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -298,5 +298,6 @@ export class QueryMock {
   cleanup() {
     nock.cleanAll();
     nock.enableNetConnect();
+    nock.restore();
   }
 }


### PR DESCRIPTION
We encountered memory leaks in our project when running integration tests using graphql-query-test-mock. Investigation revealed that it was caused by accumulation of nock overrides, which weren't restored properly. After adding `nock.restore()` call to `afterAll` jest hook alongside with `queryMock.cleanup()` the problem disappeared. This PR adds `nock.restore()` to `cleanup` method of graphql-query-test-mock.